### PR TITLE
450 extract company token from token sale

### DIFF
--- a/contracts/CompanyToken.sol
+++ b/contracts/CompanyToken.sol
@@ -9,21 +9,42 @@ import "./lib/PausableToken.sol";
  * @author Gustavo Guimaraes - <gustavo@starbase.co>
  */
 contract CompanyToken is PausableToken, MintableToken {
-    string public name;
-    string public symbol;
-    uint8 public decimals;
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
 
     /**
      * @dev Contract constructor function
-     * @param _name Token name
-     * @param _symbol Token symbol - up to 4 characters
-     * @param _decimals Decimals for token
+     * @param name Token name
+     * @param symbol Token symbol - up to 4 characters
+     * @param decimals Decimals for token
      */
-    constructor(string _name, string _symbol, uint8 _decimals) public {
-        name = _name;
-        symbol = _symbol;
-        decimals = _decimals;
+    constructor(string name, string symbol, uint8 decimals) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = decimals;
 
         pause();
+    }
+
+    /**
+     * @return the name of the token.
+     */
+    function name() public view returns (string) {
+        return _name;
+    }
+
+    /**
+     * @return the symbol of the token.
+     */
+    function symbol() public view returns (string) {
+        return _symbol;
+    }
+
+    /**
+     * @return the number of decimals of the token.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
     }
 }

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -81,7 +81,6 @@ contract TokenSale is FinalizableCrowdsale, Pausable {
         starRate = _starRate;
         isWeiAccepted = _isWeiAccepted;
         _owner = tx.origin;
-        // transferOwnership(tx.origin);
 
         initialTokenOwner = ERC20Plus(tokenOnSale).owner();
         uint256 tokenDecimals = ERC20Plus(tokenOnSale).decimals();

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 import "./lib/Pausable.sol";
 import "./lib/FinalizableCrowdsale.sol";
-import "./CompanyToken.sol";
+import "./lib/ERC20Plus.sol";
 import "./Whitelist.sol";
 import "./TokenSaleInterface.sol";
 
@@ -20,9 +20,9 @@ contract TokenSale is FinalizableCrowdsale, Pausable {
 
     // external contracts
     Whitelist public whitelist;
-    StandardToken public starToken;
+    ERC20Plus public starToken;
     // The token being sold
-    MintableToken public tokenOnSale;
+    ERC20Plus public tokenOnSale;
 
     event TokenRateChanged(uint256 previousRate, uint256 newRate);
     event TokenStarRateChanged(uint256 previousStarRate, uint256 newStarRate);
@@ -34,7 +34,7 @@ contract TokenSale is FinalizableCrowdsale, Pausable {
      * @param _endTime Timestamp when the crowdsale will finish
      * @param _whitelist contract containing the whitelisted addresses
      * @param _starToken STAR token contract address
-     * @param _companyToken ERC20 CompanyToken contract address
+     * @param _companyToken ERC20 contract address that has minting capabilities
      * @param _rate The token rate per ETH
      * @param _starRate The token rate per STAR
      * @param _wallet Multisig wallet that will hold the crowdsale funds.
@@ -75,18 +75,19 @@ contract TokenSale is FinalizableCrowdsale, Pausable {
         );
 
         initCrowdsale(_startTime, _endTime, _rate, _wallet);
-        tokenOnSale = CompanyToken(_companyToken);
+        tokenOnSale = ERC20Plus(_companyToken);
         whitelist = Whitelist(_whitelist);
-        starToken = StandardToken(_starToken);
+        starToken = ERC20Plus(_starToken);
         starRate = _starRate;
         isWeiAccepted = _isWeiAccepted;
-        owner = tx.origin;
+        _owner = tx.origin;
+        // transferOwnership(tx.origin);
 
-        initialTokenOwner = CompanyToken(tokenOnSale).owner();
-        uint256 tokenDecimals = CompanyToken(tokenOnSale).decimals();
+        initialTokenOwner = ERC20Plus(tokenOnSale).owner();
+        uint256 tokenDecimals = ERC20Plus(tokenOnSale).decimals();
         crowdsaleCap = _crowdsaleCap.mul(10 ** tokenDecimals);
 
-        require(CompanyToken(tokenOnSale).paused(), "Company token must be paused upon initialization!");
+        require(ERC20Plus(tokenOnSale).paused(), "Company token must be paused upon initialization!");
     }
 
     modifier isWhitelisted(address beneficiary) {

--- a/contracts/TokenSaleForAlreadyDeployedERC20Tokens.sol
+++ b/contracts/TokenSaleForAlreadyDeployedERC20Tokens.sol
@@ -79,7 +79,7 @@ contract TokenSaleForAlreadyDeployedERC20Tokens is FinalizableCrowdsale, Pausabl
         starToken = ERC20(_starToken);
         starRate = _starRate;
         isWeiAccepted = _isWeiAccepted;
-        owner = tx.origin;
+        _owner = tx.origin;
 
         crowdsaleCap = _crowdsaleCap;
     }

--- a/contracts/TokenSaleForAlreadyDeployedERC20Tokens.sol
+++ b/contracts/TokenSaleForAlreadyDeployedERC20Tokens.sol
@@ -80,7 +80,6 @@ contract TokenSaleForAlreadyDeployedERC20Tokens is FinalizableCrowdsale, Pausabl
         starRate = _starRate;
         isWeiAccepted = _isWeiAccepted;
         _owner = tx.origin;
-
         crowdsaleCap = _crowdsaleCap;
     }
 

--- a/contracts/lib/ERC20Plus.sol
+++ b/contracts/lib/ERC20Plus.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.4.24;
+
+
+/**
+ * @title ERC20 interface with additional functions
+ * @dev it has added functions that deals to minting, pausing token and token information
+ */
+contract ERC20Plus {
+    function allowance(address owner, address spender) public view returns (uint256);
+    function transferFrom(address from, address to, uint256 value) public returns (bool);
+    function approve(address spender, uint256 value) public returns (bool);
+    function totalSupply() public view returns (uint256);
+    function balanceOf(address who) public view returns (uint256);
+    function transfer(address to, uint256 value) public returns (bool);
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    // additonal functions
+    function mint(address _to, uint256 _amount) public returns (bool);
+    function owner() public view returns (address);
+    function transferOwnership(address newOwner) public;
+    function name() public view returns (string);
+    function symbol() public view returns (string);
+    function decimals() public view returns (uint8);
+    function paused() public view returns (bool);
+
+}

--- a/contracts/lib/Ownable.sol
+++ b/contracts/lib/Ownable.sol
@@ -7,56 +7,67 @@ pragma solidity 0.4.24;
  * functions, this simplifies the implementation of "user permissions".
  */
 contract Ownable {
-  address public owner;
+    address public _owner;
 
-  event OwnershipRenounced(address indexed previousOwner);
-  event OwnershipTransferred(
-    address indexed previousOwner,
-    address indexed newOwner
-  );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-  /**
-   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
-   * account.
-   */
-  constructor() public {
-    owner = msg.sender;
-  }
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    constructor () internal {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
 
-  /**
-   * @dev Throws if called by any account other than the owner.
-   */
-  modifier onlyOwner() {
-    require(msg.sender == owner, "only owner is able to call this function");
-    _;
-  }
+    /**
+     * @return the address of the owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
 
-  /**
-   * @dev Allows the current owner to relinquish control of the contract.
-   * @notice Renouncing to ownership will leave the contract without an owner.
-   * It will not be possible to call the functions with the `onlyOwner`
-   * modifier anymore.
-   */
-  function renounceOwnership() public onlyOwner {
-    emit OwnershipRenounced(owner);
-    owner = address(0);
-  }
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner());
+        _;
+    }
 
-  /**
-   * @dev Allows the current owner to transfer control of the contract to a newOwner.
-   * @param _newOwner The address to transfer ownership to.
-   */
-  function transferOwnership(address _newOwner) public onlyOwner {
-    _transferOwnership(_newOwner);
-  }
+    /**
+     * @return true if `msg.sender` is the owner of the contract.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
 
-  /**
-   * @dev Transfers control of the contract to a newOwner.
-   * @param _newOwner The address to transfer ownership to.
-   */
-  function _transferOwnership(address _newOwner) internal {
-    require(_newOwner != address(0));
-    emit OwnershipTransferred(owner, _newOwner);
-    owner = _newOwner;
-  }
+    /**
+     * @dev Allows the current owner to relinquish control of the contract.
+     * @notice Renouncing to ownership will leave the contract without an owner.
+     * It will not be possible to call the functions with the `onlyOwner`
+     * modifier anymore.
+     */
+    function renounceOwnership() public onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0));
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
 }

--- a/contracts/lib/Pausable.sol
+++ b/contracts/lib/Pausable.sol
@@ -9,41 +9,51 @@ import "./Ownable.sol";
  * @dev Base contract which allows children to implement an emergency stop mechanism.
  */
 contract Pausable is Ownable {
-  event Pause();
-  event Unpause();
+    event Pause();
+    event Unpause();
 
-  bool public paused = false;
+    bool private _paused;
 
+    constructor () internal {
+        _paused = false;
+    }
 
-  /**
-   * @dev Modifier to make a function callable only when the contract is not paused.
-   */
-  modifier whenNotPaused() {
-    require(!paused);
-    _;
-  }
+    /**
+     * @return true if the contract is paused, false otherwise.
+     */
+    function paused() public view returns (bool) {
+        return _paused;
+    }
 
-  /**
-   * @dev Modifier to make a function callable only when the contract is paused.
-   */
-  modifier whenPaused() {
-    require(paused);
-    _;
-  }
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     */
+    modifier whenNotPaused() {
+        require(!_paused, "must not be paused");
+        _;
+    }
 
-  /**
-   * @dev called by the owner to pause, triggers stopped state
-   */
-  function pause() onlyOwner whenNotPaused public {
-    paused = true;
-    emit Pause();
-  }
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     */
+    modifier whenPaused() {
+        require(_paused, "must be paused");
+        _;
+    }
 
-  /**
-   * @dev called by the owner to unpause, returns to normal state
-   */
-  function unpause() onlyOwner whenPaused public {
-    paused = false;
-    emit Unpause();
-  }
+    /**
+     * @dev called by the owner to pause, triggers stopped state
+     */
+    function pause() public onlyOwner whenNotPaused {
+        _paused = true;
+        emit Pause();
+    }
+
+    /**
+     * @dev called by the owner to unpause, returns to normal state
+     */
+    function unpause() onlyOwner whenPaused public {
+        _paused = false;
+        emit Unpause();
+    }
 }

--- a/test/_tokenSaleForAlreadyDeployedERC20Tokens.test.js
+++ b/test/_tokenSaleForAlreadyDeployedERC20Tokens.test.js
@@ -9,7 +9,7 @@ const expect = require("chai").expect;
 
 const BigNumber = web3.BigNumber;
 
-contract(
+contract.only(
   "TokenSaleForAlreadyDeployedERC20Tokens",
   ([owner, wallet, buyer, buyer2, user1, fakeWallet]) => {
     const starRate = new BigNumber(10);
@@ -61,15 +61,6 @@ contract(
       await newCrowdsale(rate, starRate);
       await token.mint(crowdsale.address, crowdsaleCap.mul(1e18));
     });
-
-    afterEach(
-      "check for invariant: total token supply <= total token cap",
-      async () => {
-        expect(await token.totalSupply()).to.be.bignumber.most(
-          await crowdsale.crowdsaleCap()
-        );
-      }
-    );
 
     it("deployment fails when both starRate and rate are zero", async () => {
       try {
@@ -128,7 +119,7 @@ contract(
     it("has a crowdsaleCap variable", async () => {
       const crowdsaleCapFigure = await crowdsale.crowdsaleCap();
 
-      crowdsaleCapFigure.should.be.bignumber.equal(crowdsaleCap * 1e18);
+      crowdsaleCapFigure.should.be.bignumber.equal(crowdsaleCap);
     });
 
     it("cannot call init again once initial values are set", async () => {

--- a/test/tokenSaleForAlreadyDeployedERC20Tokens.test.js
+++ b/test/tokenSaleForAlreadyDeployedERC20Tokens.test.js
@@ -9,7 +9,7 @@ const expect = require("chai").expect;
 
 const BigNumber = web3.BigNumber;
 
-contract.only(
+contract(
   "TokenSaleForAlreadyDeployedERC20Tokens",
   ([owner, wallet, buyer, buyer2, user1, fakeWallet]) => {
     const starRate = new BigNumber(10);


### PR DESCRIPTION
This abstract the companyToken contract from the TokenSale contract by adding a contract interface.

It makes deployment cheaper as CompanyToken byte code is not carried to the TokenSale anymore. 

Also, dependency smart contracts have been updated so as to add API functions that makes the interface contract workable.

